### PR TITLE
fix: stop propagating request to backend if not valid

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.gravitee.gateway</groupId>

--- a/src/main/java/io/gravitee/policy/threatprotection/json/JsonThreatProtectionPolicy.java
+++ b/src/main/java/io/gravitee/policy/threatprotection/json/JsonThreatProtectionPolicy.java
@@ -24,7 +24,9 @@ import io.gravitee.common.http.MediaType;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.stream.TransformableRequestStreamBuilder;
+import io.gravitee.gateway.api.stream.BufferedReadWriteStream;
 import io.gravitee.gateway.api.stream.ReadWriteStream;
+import io.gravitee.gateway.api.stream.SimpleReadWriteStream;
 import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.api.PolicyResult;
 import io.gravitee.policy.api.annotations.OnRequestContent;
@@ -57,12 +59,24 @@ public class JsonThreatProtectionPolicy {
     public ReadWriteStream<Buffer> onRequestContent(Request request, PolicyChain policyChain) {
         if (request.headers().getOrDefault(HttpHeaders.CONTENT_TYPE, Collections.emptyList()).contains(MediaType.APPLICATION_JSON)) {
             // The policy is only applicable to json content type.
-            return TransformableRequestStreamBuilder
-                .on(request)
-                .chain(policyChain)
-                .transform(buffer -> {
+            return new BufferedReadWriteStream() {
+                final Buffer buffer = Buffer.buffer();
+
+                @Override
+                public SimpleReadWriteStream<Buffer> write(Buffer content) {
+                    buffer.appendBuffer(content);
+                    return this;
+                }
+
+                @Override
+                public void end() {
                     try {
                         validateJson(buffer.toString());
+
+                        if (buffer.length() > 0) {
+                            super.write(buffer);
+                        }
+                        super.end();
                     } catch (JsonException e) {
                         policyChain.streamFailWith(
                             PolicyResult.failure(e.getKey(), HttpStatusCode.BAD_REQUEST_400, BAD_REQUEST, MediaType.TEXT_PLAIN)
@@ -77,10 +91,8 @@ public class JsonThreatProtectionPolicy {
                             )
                         );
                     }
-
-                    return buffer;
-                })
-                .build();
+                }
+            };
         }
 
         return null;

--- a/src/test/java/io/gravitee/policy/threatprotection/json/JsonThreatProtectionPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/threatprotection/json/JsonThreatProtectionPolicyTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.policy.threatprotection.json;
 
 import static io.gravitee.policy.threatprotection.json.JsonThreatProtectionPolicy.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -27,9 +28,13 @@ import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.api.stream.BufferedReadWriteStream;
 import io.gravitee.gateway.api.stream.ReadWriteStream;
+import io.gravitee.gateway.api.stream.SimpleReadWriteStream;
 import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.api.PolicyResult;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -154,14 +159,14 @@ public class JsonThreatProtectionPolicyTest {
         when(request.headers()).thenReturn(HttpHeaders.create());
         ReadWriteStream<?> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNull(readWriteStream);
+        assertThat(readWriteStream).isNull();
     }
 
     @Test
     public void shouldAcceptValidJson() {
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
 
         readWriteStream.write(Buffer.buffer("{ \"valid\": true, \"array\": [ 1, 2, 3 ], \"container\": { \"a\": true } }"));
         readWriteStream.end();
@@ -173,10 +178,14 @@ public class JsonThreatProtectionPolicyTest {
     public void shouldRejectInvalidJson() {
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         readWriteStream.write(Buffer.buffer("Invalid"));
         readWriteStream.end();
+
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isFalse();
 
         verify(policyChain, times(1)).streamFailWith(resultCaptor.capture());
         assertEquals(JSON_THREAT_DETECTED_KEY, resultCaptor.getValue().key());
@@ -187,10 +196,14 @@ public class JsonThreatProtectionPolicyTest {
         configuration.setMaxNameLength(4);
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         readWriteStream.write(Buffer.buffer("{ \"valid\": true, \"array\": [ 1, 2, 3 ], \"container\": { \"a\": \"123456789\" } }"));
         readWriteStream.end();
+
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isFalse();
 
         verify(policyChain, times(1)).streamFailWith(resultCaptor.capture());
         assertEquals(JSON_THREAT_MAX_NAME_LENGTH_KEY, resultCaptor.getValue().key());
@@ -201,10 +214,13 @@ public class JsonThreatProtectionPolicyTest {
         configuration.setMaxValueLength(8);
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         readWriteStream.write(Buffer.buffer("{ \"valid\": false, \"array\": [ 1, 2, 3 ], \"container\": { \"a\": \"123456789\" } }"));
         readWriteStream.end();
+
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isFalse();
 
         verify(policyChain, times(1)).streamFailWith(resultCaptor.capture());
         assertEquals(JSON_THREAT_MAX_VALUE_LENGTH_KEY, resultCaptor.getValue().key());
@@ -215,10 +231,13 @@ public class JsonThreatProtectionPolicyTest {
         configuration.setMaxEntries(2);
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         readWriteStream.write(Buffer.buffer("{ \"valid\": false, \"array\": [ 1, 2, 3 ], \"container\": { \"a\": \"123456789\" } }"));
         readWriteStream.end();
+
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isFalse();
 
         verify(policyChain, times(1)).streamFailWith(resultCaptor.capture());
         assertEquals(JSON_THREAT_MAX_ENTRIES_KEY, resultCaptor.getValue().key());
@@ -229,10 +248,13 @@ public class JsonThreatProtectionPolicyTest {
         configuration.setMaxArraySize(2);
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         readWriteStream.write(Buffer.buffer("{ \"valid\": false, \"array\": [ 1, 2, 3 ], \"container\": { \"a\": \"123456789\" } }"));
         readWriteStream.end();
+
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isFalse();
 
         verify(policyChain, times(1)).streamFailWith(resultCaptor.capture());
         assertEquals(JSON_MAX_ARRAY_SIZE_KEY, resultCaptor.getValue().key());
@@ -243,10 +265,13 @@ public class JsonThreatProtectionPolicyTest {
         configuration.setMaxArraySize(2);
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         readWriteStream.write(Buffer.buffer(JSON));
         readWriteStream.end();
+
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isFalse();
 
         verify(policyChain, times(1)).streamFailWith(any(PolicyResult.class));
     }
@@ -256,10 +281,13 @@ public class JsonThreatProtectionPolicyTest {
         configuration.setMaxArraySize(4);
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         readWriteStream.write(Buffer.buffer("{\"a\":[\"1\",\"2\",\"3\",[\"1\",\"2\",\"3\",[\"1\",\"2\",\"3\",\"4\",\"5\"]]]}"));
         readWriteStream.end();
+
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isFalse();
 
         verify(policyChain, times(1)).streamFailWith(resultCaptor.capture());
         assertEquals(JSON_MAX_ARRAY_SIZE_KEY, resultCaptor.getValue().key());
@@ -270,10 +298,13 @@ public class JsonThreatProtectionPolicyTest {
         configuration.setMaxArraySize(4);
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         readWriteStream.write(Buffer.buffer("{\"a\":[\"1\",\"2\",\"3\",[\"1\",\"2\",\"3\",[\"1\",\"2\",\"3\",\"4\"]]]}"));
         readWriteStream.end();
+
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isTrue();
 
         verifyNoInteractions(policyChain);
     }
@@ -283,10 +314,13 @@ public class JsonThreatProtectionPolicyTest {
         configuration.setMaxDepth(1);
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         readWriteStream.write(Buffer.buffer("{ \"valid\": false, \"array\": [ 1, 2, 3 ], \"container\": { \"a\": \"123456789\" } }"));
         readWriteStream.end();
+
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isFalse();
 
         verify(policyChain, times(1)).streamFailWith(resultCaptor.capture());
         assertEquals(JSON_THREAT_MAX_DEPTH_KEY, resultCaptor.getValue().key());
@@ -297,12 +331,15 @@ public class JsonThreatProtectionPolicyTest {
         configuration.setMaxDepth(6);
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         readWriteStream.write(
             Buffer.buffer("{ \"valid\": false, \"array\": [ 1, 2, 3 ], \"container\": { \"a\": [ [ [ [ [ \"123456789\" ] ] ] ] ] } }")
         );
         readWriteStream.end();
+
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isFalse();
 
         verify(policyChain, times(1)).streamFailWith(resultCaptor.capture());
         assertEquals(JSON_THREAT_MAX_DEPTH_KEY, resultCaptor.getValue().key());
@@ -313,13 +350,31 @@ public class JsonThreatProtectionPolicyTest {
         configuration.setMaxDepth(7);
         ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 
-        assertNotNull(readWriteStream);
+        assertThat(readWriteStream).isNotNull();
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = spyEndHandler(readWriteStream);
 
         readWriteStream.write(
             Buffer.buffer("{ \"valid\": false, \"array\": [ 1, 2, 3 ], \"container\": { \"a\": [ [ [ [ [ \"123456789\" ] ] ] ] ] } }")
         );
         readWriteStream.end();
 
+        assertThat(hasCalledEndOnReadWriteStreamParentClass).isTrue();
+
         verifyNoInteractions(policyChain);
+    }
+
+    /**
+     * Replace the endHandler of the resulting ReadWriteStream of the policy execution.
+     * This endHandler will set an {@link AtomicBoolean} to {@code true} if its called.
+     * It will allow us to verify if super.end() has been called on {@link BufferedReadWriteStream#end()}
+     * @param readWriteStream: the {@link ReadWriteStream} to modify
+     * @return an AtomicBoolean set to {@code true} if {@link SimpleReadWriteStream#end()}, else {@code false}
+     */
+    private AtomicBoolean spyEndHandler(ReadWriteStream readWriteStream) {
+        final AtomicBoolean hasCalledEndOnReadWriteStreamParentClass = new AtomicBoolean(false);
+        readWriteStream.endHandler(__ -> {
+            hasCalledEndOnReadWriteStreamParentClass.set(true);
+        });
+        return hasCalledEndOnReadWriteStreamParentClass;
     }
 }


### PR DESCRIPTION
Issue

https://github.com/gravitee-io/issues/issues/7301

Description

TransformableReadWriteStream will systematically do a call on write() and end() on the parent implementation when applying transformation method. It causes the chain to execute and propagate to backend even if we want to make the chain fail.

Replace usage of TransformableRequestStreamBuilder by BufferedReadWriteStream to control if we have to write() and end() the stream. We continue the request only if json is valid
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.3.2-issues-7301-stop-propagate-request-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-threat-protection/1.3.2-issues-7301-stop-propagate-request-SNAPSHOT/gravitee-policy-json-threat-protection-1.3.2-issues-7301-stop-propagate-request-SNAPSHOT.zip)
  <!-- Version placeholder end -->
