### PR TITLE
Merge `1.2.x` into `master`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.2.3](https://github.com/gravitee-io/gravitee-policy-json-threat-protection/compare/1.2.2...1.2.3) (2022-03-28)
+
+
+### Bug Fixes
+
+* stop propagating request to backend if not valid ([4880ae8](https://github.com/gravitee-io/gravitee-policy-json-threat-protection/commit/4880ae861d97d5e4dab46d43944c800e917f3132))
+
 ## [1.3.2](https://github.com/gravitee-io/gravitee-policy-json-threat-protection/compare/1.3.1...1.3.2) (2022-03-28)
 
 

--- a/src/main/java/io/gravitee/policy/threatprotection/json/JsonThreatProtectionPolicy.java
+++ b/src/main/java/io/gravitee/policy/threatprotection/json/JsonThreatProtectionPolicy.java
@@ -23,7 +23,6 @@ import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.buffer.Buffer;
-import io.gravitee.gateway.api.http.stream.TransformableRequestStreamBuilder;
 import io.gravitee.gateway.api.stream.BufferedReadWriteStream;
 import io.gravitee.gateway.api.stream.ReadWriteStream;
 import io.gravitee.gateway.api.stream.SimpleReadWriteStream;

--- a/src/test/java/io/gravitee/policy/threatprotection/json/JsonThreatProtectionPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/threatprotection/json/JsonThreatProtectionPolicyTest.java
@@ -16,10 +16,8 @@
 package io.gravitee.policy.threatprotection.json;
 
 import static io.gravitee.policy.threatprotection.json.JsonThreatProtectionPolicy.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.Assert.*;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.common.http.MediaType;
@@ -34,7 +32,6 @@ import io.gravitee.gateway.api.stream.SimpleReadWriteStream;
 import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.api.PolicyResult;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
**Issue**

NA

**Description**

Merge `1.2.x` into `master`
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.3.3-merge-1-2-into-master-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-threat-protection/1.3.3-merge-1-2-into-master-SNAPSHOT/gravitee-policy-json-threat-protection-1.3.3-merge-1-2-into-master-SNAPSHOT.zip)
  <!-- Version placeholder end -->
