### PR TITLE
Enable policy on REQUEST phase for proxy and message APIs

### DIFF
--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -6,3 +6,5 @@ class=io.gravitee.policy.threatprotection.json.JsonThreatProtectionPolicy
 type=policy
 category=security
 icon=json-threat-protection.svg
+proxy=REQUEST
+message=REQUEST


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3594
gravitee-io/issues#9430

**Description**

Enable policy on REQUEST phase for proxy and message APIs
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.4.0-gaetanmaisse-patch-1-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-threat-protection/1.4.0-gaetanmaisse-patch-1-SNAPSHOT/gravitee-policy-json-threat-protection-1.4.0-gaetanmaisse-patch-1-SNAPSHOT.zip)
  <!-- Version placeholder end -->
