### PR TITLE
fix: make jsonFactory instance-scoped to prevent duplicate-key setting race condition

### DIFF
--- a/src/main/java/io/gravitee/policy/threatprotection/json/JsonThreatProtectionPolicy.java
+++ b/src/main/java/io/gravitee/policy/threatprotection/json/JsonThreatProtectionPolicy.java
@@ -47,7 +47,7 @@ public class JsonThreatProtectionPolicy {
     public static final String JSON_MAX_ARRAY_SIZE_KEY = "JSON_MAX_ARRAY_SIZE";
     public static final String JSON_THREAT_ENFORCE_JSON = "JSON_THREAT_ENFORCE_JSON";
 
-    private static final JsonFactory jsonFactory = new JsonFactory();
+    private final JsonFactory jsonFactory = new JsonFactory();
 
     private final JsonThreatProtectionPolicyConfiguration configuration;
 

--- a/src/test/java/io/gravitee/policy/threatprotection/json/JsonThreatProtectionPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/threatprotection/json/JsonThreatProtectionPolicyTest.java
@@ -373,6 +373,60 @@ public class JsonThreatProtectionPolicyTest {
     class DuplicateKeyBehavior {
 
         @Test
+        public void should_enforce_duplicate_key_setting_independently_per_policy_instance() {
+            // Reproduces the static-jsonFactory race condition:
+            // A policy that prevents duplicate keys must still reject them after a second policy
+            // instance (configured to allow duplicates) has been constructed and used.
+            JsonThreatProtectionPolicyConfiguration allowDuplicatesConfig = new JsonThreatProtectionPolicyConfiguration();
+            allowDuplicatesConfig.setMaxArraySize(100);
+            allowDuplicatesConfig.setMaxDepth(1000);
+            allowDuplicatesConfig.setMaxEntries(100);
+            allowDuplicatesConfig.setMaxNameLength(100);
+            allowDuplicatesConfig.setMaxValueLength(100);
+            allowDuplicatesConfig.setPreventDuplicateKey(false);
+
+            // Instantiating this second policy mutates the shared static jsonFactory,
+            // disabling STRICT_DUPLICATE_DETECTION for every policy instance.
+            JsonThreatProtectionPolicy allowDuplicatesPolicy = new JsonThreatProtectionPolicy(allowDuplicatesConfig);
+            PolicyChain allowDuplicatesPolicyChain = mock(PolicyChain.class);
+            Request allowDuplicatesRequest = mock(Request.class);
+            when(allowDuplicatesRequest.headers())
+                .thenReturn(HttpHeaders.create().set(HttpHeaderNames.CONTENT_TYPE, MediaType.APPLICATION_JSON));
+
+            String jsonWithDuplicateKey =
+                """
+                {
+                    "travel": {
+                        "type": "TOURISM"
+                    },
+                    "travel": 12
+                }
+                """;
+
+            // Consume the allow-duplicates policy first (mirrors the /allow endpoint call in the reported scenario).
+            ReadWriteStream<Buffer> allowStream = allowDuplicatesPolicy.onRequestContent(
+                allowDuplicatesRequest,
+                allowDuplicatesPolicyChain
+            );
+            allowStream.endHandler(__ -> {});
+            allowStream.write(Buffer.buffer(jsonWithDuplicateKey));
+            allowStream.end();
+            verifyNoInteractions(allowDuplicatesPolicyChain);
+
+            // Now exercise the deny-duplicates policy (cut); it must still reject the same payload.
+            ReadWriteStream<Buffer> denyStream = cut.onRequestContent(request, policyChain);
+            assertThat(denyStream).isNotNull();
+            final AtomicBoolean endCalled = spyEndHandler(denyStream);
+
+            denyStream.write(Buffer.buffer(jsonWithDuplicateKey));
+            denyStream.end();
+
+            assertThat(endCalled).isFalse();
+            verify(policyChain, times(1)).streamFailWith(resultCaptor.capture());
+            assertThat(resultCaptor.getValue().key()).isEqualTo(JSON_THREAT_DETECTED_KEY);
+        }
+
+        @Test
         public void should_reject_when_duplicate_key() {
             ReadWriteStream<Buffer> readWriteStream = cut.onRequestContent(request, policyChain);
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/PEN-84

**Description**

Fixed race condition

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.1-fix-PEN-84-static-json-factory-duplicate-key-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-threat-protection/2.1.1-fix-PEN-84-static-json-factory-duplicate-key-SNAPSHOT/gravitee-policy-json-threat-protection-2.1.1-fix-PEN-84-static-json-factory-duplicate-key-SNAPSHOT.zip)
  <!-- Version placeholder end -->
